### PR TITLE
Fix issue where self might have been deallocated causing weakSelf.cancellationCompletionBlock(); to crash

### DIFF
--- a/IFACoreUI/IFACoreUI/classes/IFAWorkInProgressModalViewManager.m
+++ b/IFACoreUI/IFACoreUI/classes/IFAWorkInProgressModalViewManager.m
@@ -78,7 +78,9 @@
             weakSelf.hasBeenCancelled = YES;
             weakSelf.hudViewController.visualIndicatorMode = IFAHudViewVisualIndicatorModeProgressIndeterminate;
             weakSelf.hudViewController.detailText = NSLocalizedStringFromTable(@"Cancelling...", @"IFALocalizable", nil);
-            weakSelf.cancellationCompletionBlock();
+            if (weakSelf.cancellationCompletionBlock) {
+                weakSelf.cancellationCompletionBlock();
+            }
         };
     } else {
         self.hudViewController.detailText = nil;


### PR DESCRIPTION
Noticed this bug while clicking around in the BC app. Hard to reproduce as it needs fairly specific timing but the weakSelf.cancellationCompletionBlock() is a definite risk